### PR TITLE
week 4: writing FindMeetingQueryMethod

### DIFF
--- a/walkthroughs/week-4-tdd/project/calendar-walkthrough.md
+++ b/walkthroughs/week-4-tdd/project/calendar-walkthrough.md
@@ -74,7 +74,7 @@ mvn test
 When all the tests pass, you can be confident that your code works!
 
 **Tip**: You execute a single test method by passing the flag
-`-Dtest=FindMeetingQueryTest#testMethodName`. E.g. To run just the test method 
+`-Dtest=FindMeetingQueryTest#testMethodName`. E.g. To run just the test method
 named `optionsForNoAttendees()` you would execute:
 
 ```bash

--- a/walkthroughs/week-4-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-4-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,10 +14,42 @@
 
 package com.google.sps;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.lang.Math;
 
 public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+    if(request.getDuration() > TimeRange.WHOLE_DAY.duration()) return new ArrayList<TimeRange>();
+
+    ArrayList<TimeRange> eventTimeRanges = new ArrayList<TimeRange>();
+    Collection<String> requestAttendees = request.getAttendees();
+    for (Event e : events) {
+      if(validEvent(e, requestAttendees)) eventTimeRanges.add(e.getWhen());
+    }
+    Collections.sort(eventTimeRanges, TimeRange.ORDER_BY_START);
+    int start = TimeRange.START_OF_DAY;
+    ArrayList<TimeRange> validTimeRanges = new ArrayList<TimeRange>();
+    System.out.println("eventTimeRanges" + eventTimeRanges);
+    for (TimeRange t : eventTimeRanges) {
+        int duration = t.start() - start;
+        if (duration > 0 && duration >= request.getDuration())
+          validTimeRanges.add(TimeRange.fromStartDuration(start, duration));
+      start = Math.max(start, t.end());
+    }
+    if (TimeRange.END_OF_DAY - start > 0) {
+      validTimeRanges.add(TimeRange.fromStartDuration(start, TimeRange.END_OF_DAY - start+1));
+    }
+    return validTimeRanges;
+  }
+  private static Boolean validEvent(Event curEvent, Collection<String> queryAttendees) {
+    Set<String> curEventAttendees = curEvent.getAttendees();
+    for(String attendee : queryAttendees) {
+      if(curEventAttendees.contains(attendee)) return true;
+    }
+      return false;
   }
 }
+

--- a/walkthroughs/week-4-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-4-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -29,19 +29,22 @@ public final class FindMeetingQuery {
     for (Event e : events) {
       if(validEvent(e, requestAttendees)) eventTimeRanges.add(e.getWhen());
     }
+
     Collections.sort(eventTimeRanges, TimeRange.ORDER_BY_START);
-    int start = TimeRange.START_OF_DAY;
+
+    int pointer = TimeRange.START_OF_DAY;
     ArrayList<TimeRange> validTimeRanges = new ArrayList<TimeRange>();
-    System.out.println("eventTimeRanges" + eventTimeRanges);
+
     for (TimeRange t : eventTimeRanges) {
-        int duration = t.start() - start;
+        int duration = t.start() - pointer;
         if (duration > 0 && duration >= request.getDuration())
-          validTimeRanges.add(TimeRange.fromStartDuration(start, duration));
-      start = Math.max(start, t.end());
+          validTimeRanges.add(TimeRange.fromStartDuration(pointer, duration));
+          pointer = Math.max(pointer, t.end());
     }
-    if (TimeRange.END_OF_DAY - start > 0) {
-      validTimeRanges.add(TimeRange.fromStartDuration(start, TimeRange.END_OF_DAY - start+1));
+    if (TimeRange.END_OF_DAY - pointer > 0) {
+      validTimeRanges.add(TimeRange.fromStartDuration(pointer, TimeRange.END_OF_DAY - pointer+1));
     }
+
     return validTimeRanges;
   }
   private static Boolean validEvent(Event curEvent, Collection<String> queryAttendees) {


### PR DESCRIPTION
This PR completes the `FindMeetingQuery` method such that it passes all the test cases in `max{O(nlogn), O(nm)} ` time. where n = number of events and m = number of attendees.

The logic of the algorithm is as follows: 

- filter out the events that don't have our attendees by doing a linear pass through our `events` list. These valid TimeRanges are stored in `eventTimeRanges`.  [`O(nm)`]

- use `Collections.sort` to sort the TimeRanges in ascending order. [`O(nlogn)`]

- do a final linear pass and add the time chunks that are not occupied by an event to our list of TimeRanges in which the requested meeting can occur. [`O(n)`]
  -  `pointer` is initialized  to `TimeRange.START_OF_DAY`
  -  `duration = currentEvent.start() - pointer > 0`
  - if `duration > 0` and `duration >= request.duration()` then we know this is a valid time chunk and we can add it to our list
  - at the end of the iteration, `pointer = Math.max(currentEvent.end(), start)`. This is so that we can update our pointer to the furthest endpoint in case of nested events.


- special case: if `request.duration() > TimeRange.WHOLE_DAY.duration()` then return empty list